### PR TITLE
(PDOC-17) Add support for YARD tags in puppet code

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,6 @@ Here's an example of how you might document a 4x function:
 
 And here's an example of how you might document a class:
 
-     # Class: Example
-     #
      # This class is meant to serve as an example of how one might
      # want to document a manifest in a way that is compatible.
      # with the strings module

--- a/lib/puppetx/puppetlabs/strings/yard/templates/default/definedtype/html/docstring.erb
+++ b/lib/puppetx/puppetlabs/strings/yard/templates/default/definedtype/html/docstring.erb
@@ -1,0 +1,51 @@
+<h3 class="signature first"> Class: <%= @class_details[:name] %></h3>
+<div class="docstring">
+  <div class="discussion">
+    <p><%= @class_details[:desc] %></p>
+  </div>
+</div>
+<div class="tags">
+  <% if @class_details[:examples] != {}%>
+    <div class="examples">
+    <p class="tag_title">Examples:</p>
+    <% @class_details[:examples].each do |title, text| %>
+      <div class="inline"><p><%= title %></p></div>
+      <pre class="example code"><code><span><%= text %></span></code></pre>
+    <% end %>
+    </div>
+  <% end %>
+  <% if @class_details[:since] %>
+    <p class="tag_title">Since:</p>
+    <ul class="since">
+      <li>
+        <div class="inline">
+          <p><%= @class_details[:since] %></p>
+        </div>
+      </li>
+    </ul>
+  <% end %>
+  <% if @class_details[:return] %>
+    <p class="tag_title">Return:</p>
+    <ul class="return">
+      <li>
+        <span class ="type">
+          <% if !@class_details[:return][1].nil? %>
+            (<tt>
+              <% @class_details[:return][1].each do |type| %>
+                <%= type %>
+                <% if @class_details[:return][1].last != type %>
+                  ,
+                <% end %>
+              <% end %>
+            </tt>) —
+          <% end %>
+        </span>
+        <% if !@class_details[:return][0].nil? %>
+          <div class="inline">
+            <p><%= @class_details[:return][0] %></p>
+          </div>
+        <% end %>
+      </li>
+    </ul>
+  <% end %>
+</div>

--- a/lib/puppetx/puppetlabs/strings/yard/templates/default/definedtype/html/docstring.erb
+++ b/lib/puppetx/puppetlabs/strings/yard/templates/default/definedtype/html/docstring.erb
@@ -1,6 +1,6 @@
 <div class="docstring">
   <div class="discussion">
-    <p><%= @class_details[:desc] %></p>
+    <p><%= htmlify(@class_details[:desc]) %></p>
   </div>
 </div>
 <div class="tags">

--- a/lib/puppetx/puppetlabs/strings/yard/templates/default/definedtype/html/docstring.erb
+++ b/lib/puppetx/puppetlabs/strings/yard/templates/default/definedtype/html/docstring.erb
@@ -1,4 +1,3 @@
-<h3 class="signature first"> Class: <%= @class_details[:name] %></h3>
 <div class="docstring">
   <div class="discussion">
     <p><%= @class_details[:desc] %></p>

--- a/lib/puppetx/puppetlabs/strings/yard/templates/default/definedtype/html/header.erb
+++ b/lib/puppetx/puppetlabs/strings/yard/templates/default/definedtype/html/header.erb
@@ -1,0 +1,5 @@
+<div class='module_header'>
+  <h1>
+    <%= @header_text %>
+  </h1>
+</div>

--- a/lib/puppetx/puppetlabs/strings/yard/templates/default/definedtype/html/parameter_details.erb
+++ b/lib/puppetx/puppetlabs/strings/yard/templates/default/definedtype/html/parameter_details.erb
@@ -23,8 +23,8 @@
                 <tt>(TBD)</tt>
               <% end %>
             </span>
-          <% unless param[:module].nil? %>
-            <tt><%= "=> #{param[:module]}" %></tt>
+          <% unless param[:fq_name].nil? %>
+            <tt><%= "=> #{param[:fq_name]}" %></tt>
           <% end %>
           <% if param[:desc]%>
             —

--- a/lib/puppetx/puppetlabs/strings/yard/templates/default/definedtype/html/parameter_details.erb
+++ b/lib/puppetx/puppetlabs/strings/yard/templates/default/definedtype/html/parameter_details.erb
@@ -6,34 +6,36 @@
         <% if !param[:exists?] %>
           <strike>
         <% end %>
-         <span class="name"><%= param[:name] %></span>
-         <%# TODO: Linkify defaults that resolve to variable declarations in a different scope. %>
-         <% if param[:types] %>
-           <span class="type">
-             ( <%  param[:types].each do |type| %>
-               <tt>
-                 <% if param[:types].last != type %>
-                   <%= type %>,
-                 <% else %>
-                   <%= type %>
-                 <% end %>
-               </tt>
-             <% end %>)
-           </span>
-         <% end %>
-         <% unless param[:module].nil? %>
-           <tt><%= "=> #{param[:module]}" %></tt>
-         <% end %>
-         <% if param[:desc]%>
-           —
-           <div class="inline">
-             <p><%=  param[:desc] %></p>
-           </div>
-         <% end %>
-       </li>
-      <% if !param[:exists] %>
-        </strike>
-      <% end %>
+          <span class="name"><%= param[:name] %></span>
+          <%# TODO: Linkify defaults that resolve to variable declarations in a different scope. %>
+            <span class="type">
+              <% if param[:types] %>
+                (<%  param[:types].each do |type| %>
+                  <tt>
+                    <% if param[:types].last != type %>
+                      <%= type %>,
+                    <% else %>
+                      <%= type %>
+                    <% end %>
+                  </tt>
+                <% end %>)
+              <% else %>
+                <tt>(TBD)</tt>
+              <% end %>
+            </span>
+          <% unless param[:module].nil? %>
+            <tt><%= "=> #{param[:module]}" %></tt>
+          <% end %>
+          <% if param[:desc]%>
+            —
+            <div class="inline">
+              <p><%=  param[:desc] %></p>
+            </div>
+          <% end %>
+        <% if !param[:exists] %>
+          </strike>
+        <% end %>
+      </li>
     <% end %>
   </ul>
 </div>

--- a/lib/puppetx/puppetlabs/strings/yard/templates/default/definedtype/html/parameter_details.erb
+++ b/lib/puppetx/puppetlabs/strings/yard/templates/default/definedtype/html/parameter_details.erb
@@ -3,30 +3,37 @@
   <ul class="param">
     <% @param_details.each do |param| %>
       <li>
-        <span class="name"><%= param[:name] %></span>
-        <% unless param[:module].nil? %>
-          <%# TODO: Linkify defaults that resolve to variable declarations in a different scope. %>
-          <% if param[:types] %>
-            <span class="type">
-              ( <%  param[:types].each do |type| %>
-                <tt>
-                  <%= type %>
-                  <% if param[:types].last != type %>
-                    ,
-                  <% end %>
-                </tt>
-              <% end %>)
-            </span>
-          <% end %>
-          <tt><%= "=> #{param[:module]}" %></tt>
+        <% if !param[:exists?] %>
+          <strike>
         <% end %>
-        <% if param[:desc]%>
-          —
-          <div class="inline">
-            <p><%=  param[:desc] %></p>
-          </div>
-        <% end %>
-      </li>
+         <span class="name"><%= param[:name] %></span>
+         <%# TODO: Linkify defaults that resolve to variable declarations in a different scope. %>
+         <% if param[:types] %>
+           <span class="type">
+             ( <%  param[:types].each do |type| %>
+               <tt>
+                 <% if param[:types].last != type %>
+                   <%= type %>,
+                 <% else %>
+                   <%= type %>
+                 <% end %>
+               </tt>
+             <% end %>)
+           </span>
+         <% end %>
+         <% unless param[:module].nil? %>
+           <tt><%= "=> #{param[:module]}" %></tt>
+         <% end %>
+         <% if param[:desc]%>
+           —
+           <div class="inline">
+             <p><%=  param[:desc] %></p>
+           </div>
+         <% end %>
+       </li>
+      <% if !param[:exists] %>
+        </strike>
+      <% end %>
     <% end %>
   </ul>
 </div>

--- a/lib/puppetx/puppetlabs/strings/yard/templates/default/definedtype/html/parameter_details.erb
+++ b/lib/puppetx/puppetlabs/strings/yard/templates/default/definedtype/html/parameter_details.erb
@@ -1,18 +1,32 @@
-<h2>Parameter Summary<small>(<a href="#" class="summary_toggle">collapse</a>)</small></h2>
-<ul class="summary">
-  <% object.parameters.each do |param| %>
-    <li>
-      <a href="#">
-        <span class="summary_signature">
-          -
-          <strong><%= h param[0] %></strong>
-          <% unless param[1].nil? %>
-            <%# TODO: Linkify defaults that resolve to variable declarations in a different scope. %>
-            => <%= h param[1] %>
+<h2>Parameter Summary</h2>
+<div class="tags">
+  <ul class="param">
+    <% @param_details.each do |param| %>
+      <li>
+        <span class="name"><%= param[:name] %></span>
+        <% unless param[:module].nil? %>
+          <%# TODO: Linkify defaults that resolve to variable declarations in a different scope. %>
+          <% if param[:types] %>
+            <span class="type">
+              ( <%  param[:types].each do |type| %>
+                <tt>
+                  <%= type %>
+                  <% if param[:types].last != type %>
+                    ,
+                  <% end %>
+                </tt>
+              <% end %>)
+            </span>
           <% end %>
-        </span>
-        <%# TODO: Grab onto @param tags and insert text/type. %>
-      </a>
-    </li>
-  <% end %>
-</ul>
+          <tt><%= "=> #{param[:module]}" %></tt>
+        <% end %>
+        <% if param[:desc]%>
+          —
+          <div class="inline">
+            <p><%=  param[:desc] %></p>
+          </div>
+        <% end %>
+      </li>
+    <% end %>
+  </ul>
+</div>

--- a/lib/puppetx/puppetlabs/strings/yard/templates/default/definedtype/setup.rb
+++ b/lib/puppetx/puppetlabs/strings/yard/templates/default/definedtype/setup.rb
@@ -17,6 +17,18 @@ def parameter_details
   erb(:parameter_details)
 end
 
+def header
+  if object.type == :hostclass
+    @header_text = "Puppet Class: #{object.name}"
+  elsif object.type == :definedtype
+    @header_text = "Puppet Defined Type: #{object.name}"
+  else
+    @header_text = "#{object.name}"
+  end
+
+  erb(:header)
+end
+
 def docstring
   examples = Hash.new
   example_tags = object.tags.find_all { |tag| tag.tag_name == "example" }

--- a/lib/puppetx/puppetlabs/strings/yard/templates/default/definedtype/setup.rb
+++ b/lib/puppetx/puppetlabs/strings/yard/templates/default/definedtype/setup.rb
@@ -9,13 +9,10 @@ def parameter_details
 
   param_tags = object.tags.find_all{ |tag| tag.tag_name == "param"}
   params = object.parameters
+
   @param_details = []
 
-  params.zip(param_tags).each do |param, tag|
-    description = tag.nil? ? nil : tag.text
-    param_types = tag.nil? ? nil : tag.types
-    @param_details.push({:name => param[0], :module => param[1], :desc => description, :types => param_types})
-  end
+  @param_details = extract_param_details(params, param_tags)
 
   erb(:parameter_details)
 end
@@ -38,4 +35,34 @@ def docstring
   @class_details = {:name => object.name, :desc => object.docstring, :examples => examples, :since => since_text, :return => return_details}
 
   erb(:docstring)
+end
+
+def extract_param_details(params_hash, tags_hash)
+
+  parameter_info = []
+
+  # Extract the information for parameters that actually exist
+  params_hash.each do |param|
+    param_tag = tags_hash.find { |tag| tag.name == param[0] }
+
+    description = param_tag.nil? ? nil : param_tag.text
+    param_types = param_tag.nil? ? nil : param_tag.types
+
+    parameter_info.push({:name => param[0], :module => param[1], :desc => description, :types => param_types, :exists? => true})
+  end
+
+  # Check if there were any comments for parameters that do not exist
+  tags_hash.each do |tag|
+    param_exists = false
+    parameter_info.each do |parameter|
+      if parameter.has_value?(tag.name)
+        param_exists = true
+      end
+    end
+    if !param_exists
+      parameter_info.push({:name => tag.name, :module => nil, :desc => tag.text, :types => tag.types, :exists? => false})
+    end
+  end
+
+  parameter_info
 end

--- a/lib/puppetx/puppetlabs/strings/yard/templates/default/definedtype/setup.rb
+++ b/lib/puppetx/puppetlabs/strings/yard/templates/default/definedtype/setup.rb
@@ -61,7 +61,7 @@ end
 # @option opts [String] :fq_name The fully qualified parameter name
 # @option opts [String] :desc The description provided in the comment
 # @options opts [Array] :types The parameter type(s) specified in the comment
-# @options opts [Boolean] :exists? True only if the parameter actually exists and just not just defined in the comment
+# @options opts [Boolean] :exists? True only if the parameter exists in the documented logic and not just in a comment
 def extract_param_details(params_hash, tags_hash)
   parameter_info = []
 
@@ -79,7 +79,7 @@ def extract_param_details(params_hash, tags_hash)
   tags_hash.each do |tag|
     param_exists = false
     parameter_info.each do |parameter|
-      if parameter.has_value?(tag.name)
+      if parameter[:name] == tag.name
         param_exists = true
       end
     end

--- a/lib/puppetx/puppetlabs/strings/yard/templates/default/definedtype/setup.rb
+++ b/lib/puppetx/puppetlabs/strings/yard/templates/default/definedtype/setup.rb
@@ -1,10 +1,41 @@
 include T('default/module')
 
 def init
-  sections :header, :box_info, :pre_docstring, T('docstring'), :parameter_details
+  sections :header, :box_info, :pre_docstring, :docstring, :parameter_details
 end
 
 def parameter_details
   return if object.parameters.empty?
+
+  param_tags = object.tags.find_all{ |tag| tag.tag_name == "param"}
+  params = object.parameters
+  @param_details = []
+
+  params.zip(param_tags).each do |param, tag|
+    description = tag.nil? ? nil : tag.text
+    param_types = tag.nil? ? nil : tag.types
+    @param_details.push({:name => param[0], :module => param[1], :desc => description, :types => param_types})
+  end
+
   erb(:parameter_details)
+end
+
+def docstring
+  examples = Hash.new
+  example_tags = object.tags.find_all { |tag| tag.tag_name == "example" }
+  example_tags.each do |example|
+    examples["#{example.name}"] = example.text
+  end
+
+  return_tag = object.tags.find { |tag| tag.tag_name == "return"}
+  return_text = return_tag.nil? ? nil : return_tag.text
+  return_types = return_tag.nil? ? nil : return_tag.types
+  return_details = (return_text.nil? && return_types.nil?) ? nil : [return_text, return_types]
+
+  since_tag = object.tags.find { |tag| tag.tag_name == "since"}
+  since_text = since_tag.nil? ? nil : since_tag.text
+
+  @class_details = {:name => object.name, :desc => object.docstring, :examples => examples, :since => since_text, :return => return_details}
+
+  erb(:docstring)
 end

--- a/lib/puppetx/puppetlabs/strings/yard/templates/default/definedtype/setup.rb
+++ b/lib/puppetx/puppetlabs/strings/yard/templates/default/definedtype/setup.rb
@@ -37,8 +37,20 @@ def docstring
   erb(:docstring)
 end
 
+# Given the parameter information and YARD param tags, extracts the
+# useful information and returns it as an array of hashes which can
+# be printed and formatted in the paramters_details erb file
+#
+# @param params_hash [Array] parameter details obtained programmatically
+# @param tags_hash [Array] parameter details obtained from comments
+#
+# @return [Hash] The relevant information about each parameter
+# @option opts [String] :name The name of the parameter
+# @option opts [String] :fq_name The fully qualified parameter name
+# @option opts [String] :desc The description provided in the comment
+# @options opts [Array] :types The parameter type(s) specified in the comment
+# @options opts [Boolean] :exists? True only if the parameter actually exists and just not just defined in the comment
 def extract_param_details(params_hash, tags_hash)
-
   parameter_info = []
 
   # Extract the information for parameters that actually exist
@@ -48,7 +60,7 @@ def extract_param_details(params_hash, tags_hash)
     description = param_tag.nil? ? nil : param_tag.text
     param_types = param_tag.nil? ? nil : param_tag.types
 
-    parameter_info.push({:name => param[0], :module => param[1], :desc => description, :types => param_types, :exists? => true})
+    parameter_info.push({:name => param[0], :fq_name => param[1], :desc => description, :types => param_types, :exists? => true})
   end
 
   # Check if there were any comments for parameters that do not exist
@@ -60,7 +72,7 @@ def extract_param_details(params_hash, tags_hash)
       end
     end
     if !param_exists
-      parameter_info.push({:name => tag.name, :module => nil, :desc => tag.text, :types => tag.types, :exists? => false})
+      parameter_info.push({:name => tag.name, :fq_name => nil, :desc => tag.text, :types => tag.types, :exists? => false})
     end
   end
 


### PR DESCRIPTION
Prior to this commit, most of the HTML created for documenting
puppet code was auto-generated by YARD, meaning that it was not
always presented in a way that was consistent or easy to read. 

Now we are explicitly defining the HTML and styling that we want
to use when generating documentation for defined types and classes.
This means that we can define exactly how we want the output to look
so that is more compatible with puppet code.

I have yet to add links to any of the details around parameters because it's
not clear to me where those links should go at the moment. It should be
simple to add them though when we decide what we want them to look like.