### PR TITLE
(PDOC-27) Don't require options for 3x functions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,11 +10,11 @@ puppetversion = ENV['PUPPET_VERSION']
 if puppetversion
   gem 'puppet', puppetversion
 else
-  gem 'puppet', '~> 3.6.2'
+  gem 'puppet'
 end
 
 group :test do
-  gem 'rspec'
+  gem "rspec", "~> 2.14.0", :require => false
   gem 'mocha'
   gem 'puppetlabs_spec_helper'
   gem 'rspec-html-matchers'

--- a/lib/puppet_x/puppetlabs/strings/yard/handlers/puppet_3x_function_handler.rb
+++ b/lib/puppet_x/puppetlabs/strings/yard/handlers/puppet_3x_function_handler.rb
@@ -73,11 +73,13 @@ class PuppetX::PuppetLabs::Strings::YARD::Handlers::Puppet3xFunctionHandler < YA
         # and the values on either side of it.
         tuple.jump(:assoc).map{|e| process_element(e)}
       end
+
+      options = Hash[opts]
     else
-      opts = [[]]
+      options = {}
     end
 
-    [name, Hash[opts]]
+    [name, options]
   end
 
   # Sometimes the YARD parser returns Heredoc strings that start with `<-`

--- a/lib/puppet_x/puppetlabs/strings/yard/handlers/puppet_3x_function_handler.rb
+++ b/lib/puppet_x/puppetlabs/strings/yard/handlers/puppet_3x_function_handler.rb
@@ -66,10 +66,15 @@ class PuppetX::PuppetLabs::Strings::YARD::Handlers::Puppet3xFunctionHandler < YA
 
     name = process_element(name)
 
-    opts = opts.map do |tuple|
-      # Jump down into the S-Expression that represents a hashrocket, `=>`,
-      # and the values on either side of it.
-      tuple.jump(:assoc).map{|e| process_element(e)}
+    # Don't try to process options if we don't have any
+    if !opts.nil?
+      opts = opts.map do |tuple|
+        # Jump down into the S-Expression that represents a hashrocket, `=>`,
+        # and the values on either side of it.
+        tuple.jump(:assoc).map{|e| process_element(e)}
+      end
+    else
+      opts = [[]]
     end
 
     [name, Hash[opts]]

--- a/spec/unit/puppet_x/puppetlabs/strings/pops_spec.rb
+++ b/spec/unit/puppet_x/puppetlabs/strings/pops_spec.rb
@@ -21,18 +21,18 @@ describe PuppetX::PuppetLabs::Strings::Pops do
     let(:manifest_default) {"#hello world\nclass foo($bar = 3) { }"}
     let(:transformer) {PuppetX::PuppetLabs::Strings::Pops::YARDTransformer.new}
 
-     describe "transform method" do
-       it "should perform the correct transformation with parameter defaults" do
+    describe "transform method" do
+      it "should perform the correct transformation with parameter defaults" do
         model = parser.parse_string(manifest_default).current.definitions.first
         statements = transformer.transform(model)
         expect(statements.parameters[0][0].class).to be(PuppetX::PuppetLabs::Strings::Pops::YARDStatement)
-       end
+      end
 
-       it "should perform the correct transofmration without parameter defaults" do
+      it "should perform the correct transofmration without parameter defaults" do
         model = parser.parse_string(manifest).current.definitions.first
         statements = transformer.transform(model)
         expect(statements.parameters[0][1].class).to be(NilClass)
-       end
+      end
     end
   end
 end

--- a/spec/unit/puppet_x/puppetlabs/strings/yard/puppet_3x_function_handler_spec.rb
+++ b/spec/unit/puppet_x/puppetlabs/strings/yard/puppet_3x_function_handler_spec.rb
@@ -51,4 +51,13 @@ describe PuppetX::PuppetLabs::Strings::YARD::Handlers::Puppet3xFunctionHandler d
     expect(the_method).to document_a(:type => :method, :docstring => "")
     expect(the_namespace).to document_a(:type => :puppetnamespace)
   end
+
+  it "should process documentation if only one option is passed to newfunction" do
+    parse <<-RUBY
+      newfunction(:the_functiion) do |args|
+      end
+    RUBY
+
+      expect(the_namespace).to document_a(:type => :puppetnamespace)
+  end
 end


### PR DESCRIPTION
Prior to this commit, the 3x function handler assumed that at
least two arguments (the name and one or more additional arguments)
were passed into newfunction when creating a 3x function. However
that is not actually required, the only argument needed is the name.

Update the 3x function handler so that it will not throw and exception
if only one argument is given.