### PR TITLE
(PDOC-25) Fix mangled puppet namespaces

### DIFF
--- a/lib/puppet_x/puppetlabs/strings/yard/core_ext/yard.rb
+++ b/lib/puppet_x/puppetlabs/strings/yard/core_ext/yard.rb
@@ -1,0 +1,40 @@
+require 'yard'
+
+require 'puppet_x/puppetlabs/strings'
+
+# Patch the regular expression used to match namespaces
+# so it will allow namespace segments that begin with
+# both uppercase and lowercase letters (i.e. both
+# Puppet::Namespace and puppet::namespace)
+YARD::CodeObjects.send(:remove_const, :CONSTANTMATCH)
+YARD::CodeObjects::CONSTANTMATCH = /[a-zA-Z]\w*/
+
+# This is a temporary hack until a new version of YARD is
+# released. We submitted a patch to YARD to add the
+# CONSTANTSTART constant so that we could patch it and
+# successfully match our own namesapces. However until
+# the next version of the YARD gem is released, we must
+# patch the problematic method itself as it is not yet
+# using the added variable
+if defined? YARD::CodeObjects::CONSTANTSTART
+  YARD::CodeObjects.send(:remove_const, :CONSTANTSTART)
+  YARD::CodeObjects::CONSTANTSTART = /^[a-zA-Z]/
+else
+  class YARD::CodeObjects::Proxy
+    def proxy_path
+      if @namespace.root?
+        (@imethod ? YARD::CodeObjects::ISEP : "") + name.to_s
+      elsif @origname
+        if @origname =~ /^[a-zA-Z]/
+          @origname
+        else
+          [namespace.path, @origname].join
+        end
+      elsif name.to_s =~ /^[a-zA-Z]/ # const
+        name.to_s
+      else # class meth?
+        [namespace.path, name.to_s].join(YARD::CodeObjects::CSEP)
+      end
+    end
+  end
+end

--- a/lib/puppet_x/puppetlabs/strings/yard/handlers/base.rb
+++ b/lib/puppet_x/puppetlabs/strings/yard/handlers/base.rb
@@ -1,3 +1,5 @@
+require 'puppet_x/puppetlabs/strings/yard/core_ext/yard'
+
 class PuppetX::PuppetLabs::Strings::YARD::Handlers::Base < YARD::Handlers::Base
   # Easy access to Pops model objects for handler matching.
   include Puppet::Pops::Model

--- a/spec/unit/puppet_x/puppetlabs/strings/yard/defined_type_handler_spec.rb
+++ b/spec/unit/puppet_x/puppetlabs/strings/yard/defined_type_handler_spec.rb
@@ -58,4 +58,17 @@ describe PuppetX::PuppetLabs::Strings::YARD::Handlers::DefinedTypeHandler do
 
     expect(YARD::Registry.all).to be_empty
   end
+
+  it "should generate the correct namespace " do
+    puppet_code =  <<-PUPPET
+        define puppet_enterprise::mcollective::client::certs { }
+    PUPPET
+
+    parse(puppet_code, :puppet)
+    # If the namespace is not correctly generated, we will not be able to find the
+    # object via this name, meaning namespace will be nil
+    namespace = YARD::Registry.at("puppet_enterprise::mcollective::client::certs").namespace.to_s
+
+    expect(namespace).to_not be_nil
+  end
 end

--- a/spec/unit/puppet_x/puppetlabs/strings/yard/host_class_handler_spec.rb
+++ b/spec/unit/puppet_x/puppetlabs/strings/yard/host_class_handler_spec.rb
@@ -46,4 +46,17 @@ describe PuppetX::PuppetLabs::Strings::YARD::Handlers::HostClassHandler do
 
     expect(the_hostclass).to document_a(:type => :hostclass, :docstring => "")
   end
+
+  it "should generate the correct namespace " do
+    puppet_code =  <<-PUPPET
+        class puppet_enterprise::mcollective::client::certs { }
+    PUPPET
+
+    parse(puppet_code, :puppet)
+    # If the namespace is not correctly generated, we will not be able to find the
+    # object via this name, meaning namespace will be nil
+    namespace = YARD::Registry.at("puppet_enterprise::mcollective::client::certs")
+
+    expect(namespace).to_not be_nil
+  end
 end


### PR DESCRIPTION
Prior to this commit, puppet namespaces would be totally mangled when
processed by YARD since YARD is looking for Ruby namespaces where the
first letter of each segment must be uppercase.

In order to fix this, patch the relevant regular expression constants
in YARD so that they will accept segments that begin with uppercase
and lowercase letters.

An upstream pull request has been accepted into YARD to add another
regex constant which is necessary to complete this patch. However until
the next version of the YARD gem is released, we must include a temporary
hack to fix the problematic method in question (as it is not yet using
the added variable). Once the new version is released, the conditional
statement in code_ext/yard.rb can be removed entirely and all we will
need to do is patch the two regex constants.