### PR TITLE
Use different debuggers for ruby 2 and 1.9

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,5 +26,9 @@ end
 
 group :development do
   gem 'pry'
-  gem 'pry-debugger'
+  if RUBY_VERSION[0..2] == '1.9'
+    gem 'pry-debugger'
+  elsif RUBY_VERSION[0] == '2'
+    gem 'pry-byebug'
+  end
 end


### PR DESCRIPTION
The debugger gem does not support ruby 2.0.
The byebug gem does not support ruby < 2.0.
Conditionally specify the right gem for the right version of ruby.