### PR TITLE
(maint) Remove html-matchers dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,10 +14,9 @@ else
 end
 
 group :test do
-  gem "rspec", "~> 2.14.1", :require => false
+  gem "rspec"
   gem 'mocha'
   gem 'puppetlabs_spec_helper'
-  gem 'rspec-html-matchers'
   gem 'serverspec'
   gem 'beaker'
   gem 'beaker-rspec'

--- a/spec/unit/puppet/face_spec.rb
+++ b/spec/unit/puppet/face_spec.rb
@@ -1,6 +1,5 @@
 require 'spec_helper'
 require 'puppet/face/strings'
-require 'rspec-html-matchers'
 require 'tmpdir'
 require 'stringio'
 
@@ -41,7 +40,7 @@ describe Puppet::Face do
 
           Puppet::Face[:strings, :current].yardoc
 
-          expect(read_html(tmp, 'test', 'test.html')).to have_tag('.docstring .discussion', :text => /This class/)
+          expect(read_html(tmp, 'test', 'test.html')).to include("Class: test")
         end
       end
 
@@ -51,7 +50,7 @@ describe Puppet::Face do
 
           Puppet::Face[:strings, :current].yardoc
 
-          expect(read_html(tmp, 'test', 'Puppet3xFunctions.html')).to have_tag('.docstring .discussion', :text => /documentation for `function3x`/)
+          expect(read_html(tmp, 'test', 'Puppet3xFunctions.html')).to include("This is the function documentation for `function3x`")
         end
       end
 
@@ -61,7 +60,7 @@ describe Puppet::Face do
 
           Puppet::Face[:strings, :current].yardoc
 
-          expect(read_html(tmp, 'test', 'Puppet4xFunctions.html')).to have_tag('.docstring .discussion', :text => /This is a function/)
+          expect(read_html(tmp, 'test', 'Puppet4xFunctions.html')).to include("This is a function which is used to test puppet strings")
         end
       end
     end


### PR DESCRIPTION
Prior to this commit, some of the unit tests for strings relied on
the rspec-html-matchers gem, which does not seem to get along with
rspec 3. This meant that we had to tie our tests to rspec 2 which
has become too inconvenient.

In order to remove the gem, use simple string matching instead.
Update the Gemfile so that it no longer requires the matchers and
no longer has rspec tied to 2.7.