### PR TITLE
(PDOC-21) Only create HostClass parameters once

### DIFF
--- a/lib/puppet_x/puppetlabs/strings/yard/handlers/host_class_handler.rb
+++ b/lib/puppet_x/puppetlabs/strings/yard/handlers/host_class_handler.rb
@@ -2,11 +2,11 @@ class PuppetX::PuppetLabs::Strings::YARD::Handlers::HostClassHandler < PuppetX::
   handles HostClassDefinition
 
   process do
-    obj = HostClassObject.new(:root, statement.pops_obj.name) do |o|
-      o.parameters = statement.parameters.map do |a|
-        param_tuple = [a[0].pops_obj.name]
-        param_tuple << ( a[1].nil? ? nil : a[1].source )
-      end
+    obj = HostClassObject.new(:root, statement.pops_obj.name)
+
+    obj.parameters = statement.parameters.map do |a|
+      param_tuple = [a[0].pops_obj.name]
+      param_tuple << ( a[1].nil? ? nil : a[1].source )
     end
     tp = Puppet::Pops::Types::TypeParser.new
     param_type_info = {}


### PR DESCRIPTION
You can pass a block to the constructor of the hostclass. For some reason Yard
is yielding the block twice. Our code is not yielding the block because we only
use yield in one place which is unrelated. I don't think this is intended
behavior on yard's part, it certainly seems odd, but we can dodge the question
and not have to wait for an upstream patch by extracting the logic from the
block and running it after the object has been initialized.