### PR TITLE
(PDOC-45) Puppet 4x functions handle unusual names

### DIFF
--- a/lib/puppet_x/puppetlabs/strings/yard/handlers/puppet_4x_function_handler.rb
+++ b/lib/puppet_x/puppetlabs/strings/yard/handlers/puppet_4x_function_handler.rb
@@ -187,6 +187,7 @@ class Puppet4xFunctionHandler < YARD::Handlers::Ruby::Base
 
     name = process_element(name)
 
+
     name
   end
 
@@ -199,12 +200,12 @@ class Puppet4xFunctionHandler < YARD::Handlers::Ruby::Base
     # @param ele [YARD::Parser::Ruby::AstNode]
     # @return [String]
     def process_element(ele)
-      ele = ele.jump(:ident, :string_content)
+      ele = ele.jump(:ident, :string_content, :tstring_content)
 
       case ele.type
       when :ident
         ele.source
-      when :string_content
+      when :string_content, :tstring_content
         source = ele.source
         if HEREDOC_START.match(source)
           process_heredoc(source)

--- a/spec/unit/puppet_x/puppetlabs/strings/yard/puppet_4x_function_handler_spec.rb
+++ b/spec/unit/puppet_x/puppetlabs/strings/yard/puppet_4x_function_handler_spec.rb
@@ -173,4 +173,17 @@ describe PuppetX::PuppetLabs::Strings::YARD::Handlers::Puppet4xFunctionHandler d
         RUBY
       }.to output("").to_stdout_from_any_process
   end
+
+  it "should parse unusually named functions" do
+    # This should not raise a ParseErrorWithIssue exceptoin
+    parse <<-RUBY
+      Puppet::Functions.create_function :'max' do
+        def max(num_a, num_b)
+          num_a >= num_b ? num_a : num_b
+        end
+      end
+    RUBY
+  end
+
+
 end


### PR DESCRIPTION
`lib/puppet/functions/defined.rb` has some unusual syntax:

	Puppet::Functions.create_function(:'defined', ....

It runs, so apparently this is legal.