### PR TITLE
(PDOC-35) Format generated html properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Installing the Yard Gem
 -----------------------
 
 **Installing the Yard Gem with Puppet**
+
+
 The easiest way to install the Yard gem is with Puppet itself.
 
 For Puppet 4.x:

--- a/lib/puppet_x/puppetlabs/strings/yard/templates/default/html_helper.rb
+++ b/lib/puppet_x/puppetlabs/strings/yard/templates/default/html_helper.rb
@@ -118,7 +118,7 @@ class HTMLHelper
       end
 
       if param[:allowed_values] and param[:allowed_values] != []
-        result << "<b> Allowed Values: </b>"
+        result << "\n<b> Allowed Values: </b>"
         result << "<ul>"
         param[:allowed_values].each do |value_thing|
           result << "<li>"


### PR DESCRIPTION
Shaigy Nixon on Jira:
"Just a trivial thing. Looks like one line break is missing from the type's
output html between the property and the allowed values for parameter. Rest all
looks great."
https://tickets.puppetlabs.com/browse/PDOC-35?focusedCommentId=215400&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-215400

As an aside, I would really like to rewrite this method to be a real erb
template and not this nonsense.