### PR TITLE
metadata.json: Use SPDX standardized short identifier for license

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,7 @@
   "version": "0.3.1",
   "author": "Puppet Labs",
   "summary": "Puppet documentation via YARD",
-  "license": "Apache 2.0",
+  "license": "Apache-2.0",
   "source": "https://github.com/puppetlabs/puppetlabs-strings",
   "project_page": "https://github.com/puppetlabs/puppetlabs-strings",
   "issues_url": "https://tickets.puppetlabs.com/browse/PDOC",


### PR DESCRIPTION
This commit changes the metadata.json to use the
SPDX licence short identifier in the metadata.json.

SPDX is an effort from the Linux foundation to easily
parse and identify open-source licenses. Some tools
in the Puppet Ecosystem relies on those short
identifiers, like the metadata-json-lint project.

- https://spdx.org/licenses
- https://github.com/puppet-community/metadata-json-lint