### PR TITLE
(maint) Fix ruby namespacing issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ Gemfile.lock
 
 ## YARD
 .yardoc
+.yardwarns
 
 ## MODULE BUILDS
 **/pkg

--- a/lib/puppet_x/puppetlabs/strings/yard/handlers/base.rb
+++ b/lib/puppet_x/puppetlabs/strings/yard/handlers/base.rb
@@ -1,6 +1,6 @@
 require 'puppet_x/puppetlabs/strings/yard/core_ext/yard'
 
-class PuppetX::PuppetLabs::Strings::YARD::Handlers::Base < YARD::Handlers::Base
+class PuppetX::PuppetLabs::Strings::YARD::Handlers::Base < ::YARD::Handlers::Base
   # Easy access to Pops model objects for handler matching.
   include Puppet::Pops::Model
   # Easy access to custom code objects from which documentation is generated.


### PR DESCRIPTION
Prior to this commit, strings would raise an error when the server
command was run against a module directory that contained the strings
module. This was due to the fact that we were trying to reference
the YARD namespace but our own namespace was being prepending to the
front, making Ruby think the two class were the same.

In order to stop this from happening, prepend a :: to the front of the
YARD version of the class to tell Ruby that we mean the YARD namespace.