### PR TITLE
Fix issue running strings:generate without a yardopts file

### DIFF
--- a/lib/puppet_x/puppetlabs/strings/util.rb
+++ b/lib/puppet_x/puppetlabs/strings/util.rb
@@ -15,14 +15,14 @@ module PuppetX::PuppetLabs::Strings::Util
     # by using the `.yardopts` file. YARD will autoload any options placed in
     # that file.
     options = args.pop
-    YARD::Config.options = YARD::Config.options.merge(options)
+    YARD::Config.options = YARD::Config.options.merge(options) if options
 
     # For now, assume the remaining positional args are a list of manifest
     # and ruby files to parse.
     yard_args = (args.empty? ? MODULE_SOURCEFILES : args)
 
     # If json is going to be emitted to stdout, suppress statistics.
-    if options[:emit_json_stdout]
+    if options && options[:emit_json_stdout]
       yard_args.push('--no-stats')
     end
 


### PR DESCRIPTION
Without a .yardopts options array.pop is nil, and everything explodes
with an exception. Applying this patch allowed for running rake
strings:generate cleanly.

Note that this did not affect strings:serve.