### PR TITLE
(PDOC-70) Always generate the JSON doc when running the rake task

### DIFF
--- a/lib/puppet-strings/rake_tasks.rb
+++ b/lib/puppet-strings/rake_tasks.rb
@@ -6,7 +6,9 @@ require 'puppet_x/puppetlabs/strings/util'
 namespace :strings do
   desc 'Generate Puppet documentation with YARD.'
   task :generate do
-    PuppetX::PuppetLabs::Strings::Util.generate
+    PuppetX::PuppetLabs::Strings::Util.generate([
+      {emit_json: 'strings.json'}
+    ])
   end
 
   desc 'Serve YARD documentation for modules.'


### PR DESCRIPTION
I'm super enthusiastic about the potential for folks to build things on
top of the JSON output, we've had several related conversations at
Config Management Camp and on puppet-dev recently. I think this is a
sane default, and calling the file strings.json seems a nice
reinforcement.