### PR TITLE
(PDOC-74) Deprecate module in favor of gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+**PLEASE NOTE that the puppetlabs-strings module is being deprecated in favor of a gem. 0.4.0 will be the last release of
+the puppet module and the first release of the Ruby gem. Please see the installation instructions below.**
+
 Puppet Strings
 =============
 [![Build Status](https://travis-ci.org/puppetlabs/puppetlabs-strings.png?branch=master)](https://travis-ci.org/puppetlabs/puppetlabs-strings)
@@ -52,6 +55,22 @@ $ puppet resource package yard provider=gem
 
 Installing Strings Itself
 -------------------------
+Strings can be installed using the [puppet-strings Ruby gem](https://rubygems.org/gems/puppet-strings). To ensure it
+is installed in right place, it is best to install it using Puppet.
+
+For Puppet 4.x:
+```
+$ puppet resource package puppet-strings provider=puppet_gem
+```
+
+For Puppet 3.x:
+```
+$ puppet resource package puppet-strings provider=gem
+```
+
+Versions of less than or equal to 0.4.0 may be installed as a puppet module, but **this method of distribution is
+deprecated and the module hosted on the Puppet Forge will no longer be updated after the 0.4.0 release.** The methods
+for installing the module are:
 
 Strings can be installed from the [Puppet Forge][forge strings] or from source.
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-strings",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "author": "Puppet Labs",
   "summary": "Puppet documentation via YARD",
   "license": "Apache-2.0",

--- a/puppet-strings.gemspec
+++ b/puppet-strings.gemspec
@@ -1,16 +1,11 @@
-require 'json'
-
-puppet_metadata = JSON.load File.open(File.expand_path(File.join(__FILE__, '..', 'metadata.json'))).read
-
 Gem::Specification.new do |s|
   s.name = 'puppet-strings'
-
-  %w(author version license summary).each do |section|
-    s.send("#{section}=", puppet_metadata[section])
-  end
-
+  s.author = 'Puppet Labs'
+  s.version = '0.4.0'
+  s.license = 'Apache-2.0'
+  s.summary = 'Puppet documentation via YARD'
   s.email = 'info@puppetlabs.com'
-  s.homepage = puppet_metadata['project_page']
+  s.homepage = 'https://github.com/puppetlabs/puppetlabs-strings'
   s.description = s.summary
   s.files = Dir['lib/**/*'].reject { |f| f if File.directory?(f) }
 


### PR DESCRIPTION
Since it's been agreed that strings is better distributed as a gem, 
do the necessary updates so that we can do a final deprecated release 
of the module in conjunction with the first release of the gem. 

This will also give us a vehicle to release the last of the work @iankronquist 
did this summer and get the JSON generations into the hands of users to try
it out.

![funny-gif-girl-party-mad-breaking-things](https://cloud.githubusercontent.com/assets/1707248/13830478/209160cc-eb8a-11e5-95d8-336eaa551bb5.gif)
