### PR TITLE
(maint) Don't install beaker for spec tests in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 sudo: false
-bundler_args: --without development
+bundler_args: --without development acceptance
 script:
   - "bundle exec rake $CHECK"
 notifications:

--- a/Gemfile
+++ b/Gemfile
@@ -18,9 +18,12 @@ group :test do
   gem 'mocha'
   gem 'puppetlabs_spec_helper'
   gem 'serverspec'
+  gem 'rubocop'
+end
+
+group :acceptance do
   gem 'beaker'
   gem 'beaker-rspec'
-  gem 'rubocop'
 end
 
 group :development do


### PR DESCRIPTION
Prior to this commit, the beaker gem and all its dependencies were
being installed just to run spec tests. Excluding beaker when running
spec tests should make things go faster because we won't have to
install so many gems.