### PR TITLE
(PDOC-75) Work with both versions of 'interpret_any'

### DIFF
--- a/lib/puppet_x/puppetlabs/strings/yard/handlers/host_class_handler.rb
+++ b/lib/puppet_x/puppetlabs/strings/yard/handlers/host_class_handler.rb
@@ -16,7 +16,13 @@ class PuppetX::PuppetLabs::Strings::YARD::Handlers::HostClassHandler < PuppetX::
         param_type_info[pop_param.name] = Puppet::Pops::Types::TypeFactory.any()
       else
         begin
-          param_type_info[pop_param.name] =  tp.interpret_any(pop_param.type_expr)
+          # This is a bit of a hack because we were using a method that was previously
+          # API private. See PDOC-75 for more details
+          if Puppet::Pops::Types::TypeParser.instance_method(:interpret_any).arity == 2
+            param_type_info[pop_param.name] = tp.interpret_any(pop_param.type_expr, nil)
+          else
+            param_type_info[pop_param.name] = tp.interpret_any(pop_param.type_exp)
+          end
         rescue Puppet::ParseError => e
           # If the type could not be interpreted insert a prominent warning
           param_type_info[pop_param.name] = "Type Error: #{e.message}"

--- a/spec/lib/strings_spec/parsing.rb
+++ b/spec/lib/strings_spec/parsing.rb
@@ -20,7 +20,7 @@ module StringsSpec
         @mismatches.empty?
       end
 
-      failure_message_for_should do
+      failure_message do |actual|
         @mismatches.collect do |key, value|
           "Expected #{key} to be <#{value[1]}>, but got <#{value[0]}>."
         end.join("\n")


### PR DESCRIPTION
Prior to this commit, strings would fail with puppet 4.4.0 and
newer. This was because strings was making use of a method that was
marked API private and thus subject to change. The method was changed
in 4.4.0 release of puppet to take two variables, meaning that strings
much adjust how it calls the method based on the version of puppet
it's running with.