### PR TITLE
Add Puppet type name in front of the provider name

### DIFF
--- a/lib/puppet_x/puppetlabs/strings/yard/handlers/provider_handler.rb
+++ b/lib/puppet_x/puppetlabs/strings/yard/handlers/provider_handler.rb
@@ -25,6 +25,7 @@ class PuppetX::PuppetLabs::Strings::YARD::Handlers::PuppetProviderHandler < YARD
     i = statement.index { |s| YARD::Parser::Ruby::AstNode === s && s.type == :ident && s.source == 'provide' }
     provider_name = statement[i+1].jump(:ident).source
     type_name = statement.jump(:symbol).first.source
+    provider_name = "#{type_name}:#{provider_name}"
 
     obj = ProviderObject.new(:root, "#{provider_name}_provider")
 


### PR DESCRIPTION
It will prevent providers of different types but with
the same name from merging together.
For example:
type1:ruby
type2:ruby
type3:ruby
Will be different providers instead of the one "ruby" provider.