### PR TITLE
(maint) Require rspec 3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ else
 end
 
 group :test do
-  gem "rspec"
+  gem "rspec", "~> 3.1"
   gem 'mocha'
   gem 'puppetlabs_spec_helper'
   gem 'serverspec'


### PR DESCRIPTION
Prior to this commit, the Gemfile did not specify an rspec version
but relied on methods that were only in rspec 3. In order to prevent
failures when running with versions older than 3, tie the specs to
3.1 or greater, which is what puppet does.