### PR TITLE
(maint) Update acceptance tests to use gem

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -18,7 +18,7 @@ task :validate do
 end
 
 task :acceptance do
-  sh "puppet module build"
+  sh "gem build puppet-strings.gemspec"
   sh "puppet module build spec/unit/puppet/examples/test"
   sh "BEAKER_set=#{ENV["platform"]} rspec spec/acceptance/*.rb"
 end

--- a/spec/acceptance/nodesets/fedora23.yml
+++ b/spec/acceptance/nodesets/fedora23.yml
@@ -2,9 +2,9 @@ HOSTS:
   master:
     roles:
       - master
-    platform: fedora-20-x86_64
+    platform: fedora-23-x86_64
     hypervisor: vcloud
-    template: Delivery/Quality Assurance/Templates/vCloud/fedora-20-x86_64
+    template: Delivery/Quality Assurance/Templates/vCloud/fedora-23-x86_64
 CONFIG:
   filecount: 12
   datastore: instance0

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -14,8 +14,8 @@ RSpec.configure do |c|
   c.before :suite do
 
   hosts.each do |host|
-      scp_to(host, Dir.glob('pkg/puppetlabs-strings*.gz').first, 'strings.tar.gz')
-      on host, puppet('module', 'install', 'strings.tar.gz')
+      scp_to(host, Dir.glob('puppet-strings*.gem').first, 'puppet-strings.gem')
+      on host, 'gem install puppet-strings.gem'
 
       scp_to(host, Dir.glob('spec/unit/puppet/examples/test/pkg/username-test*.gz').first, 'test.tar.gz')
       on host, puppet('module', 'install', 'test.tar.gz')


### PR DESCRIPTION
Prior to this commit, the acceptance tests were trying to install
strings as a module and failing due to the fact that strings has
transition to a gem and does not have metadata. Update the tests
so that they install strings as a gem instead.