### PR TITLE
(PDOC-71) Workaround for spurious error failures

### DIFF
--- a/lib/puppet_x/puppetlabs/strings/yard/handlers/host_class_handler.rb
+++ b/lib/puppet_x/puppetlabs/strings/yard/handlers/host_class_handler.rb
@@ -2,41 +2,54 @@ class PuppetX::PuppetLabs::Strings::YARD::Handlers::HostClassHandler < PuppetX::
   handles HostClassDefinition
 
   process do
-    obj = HostClassObject.new(:root, statement.pops_obj.name)
+    begin
+      obj = HostClassObject.new(:root, statement.pops_obj.name)
 
-    obj.parameters = statement.parameters.map do |a|
-      param_tuple = [a[0].pops_obj.name]
-      param_tuple << ( a[1].nil? ? nil : a[1].source )
-    end
-    tp = Puppet::Pops::Types::TypeParser.new
-    param_type_info = {}
-    statement.pops_obj.parameters.each do |pop_param|
-      # If the parameter's type expression is nil, default to Any
-      if pop_param.type_expr == nil
-        param_type_info[pop_param.name] = Puppet::Pops::Types::TypeFactory.any()
-      else
-        begin
-          # This is a bit of a hack because we were using a method that was previously
-          # API private. See PDOC-75 for more details
-          if Puppet::Pops::Types::TypeParser.instance_method(:interpret_any).arity == 2
-            param_type_info[pop_param.name] = tp.interpret_any(pop_param.type_expr, nil)
-          else
-            param_type_info[pop_param.name] = tp.interpret_any(pop_param.type_expr)
+      obj.parameters = statement.parameters.map do |a|
+        param_tuple = [a[0].pops_obj.name]
+        param_tuple << ( a[1].nil? ? nil : a[1].source )
+      end
+      tp = Puppet::Pops::Types::TypeParser.new
+      param_type_info = {}
+      statement.pops_obj.parameters.each do |pop_param|
+        # If the parameter's type expression is nil, default to Any
+        if pop_param.type_expr == nil
+          param_type_info[pop_param.name] = Puppet::Pops::Types::TypeFactory.any()
+        else
+          begin
+            # This is a bit of a hack because we were using a method that was previously
+            # API private. See PDOC-75 for more details
+            if Puppet::Pops::Types::TypeParser.instance_method(:interpret_any).arity == 2
+              param_type_info[pop_param.name] = tp.interpret_any(pop_param.type_expr, nil)
+            else
+              param_type_info[pop_param.name] = tp.interpret_any(pop_param.type_expr)
+            end
+          rescue Puppet::ParseError => e
+            # If the type could not be interpreted insert a prominent warning
+            param_type_info[pop_param.name] = "Type Error: #{e.message}"
           end
-        rescue Puppet::ParseError => e
-          # If the type could not be interpreted insert a prominent warning
-          param_type_info[pop_param.name] = "Type Error: #{e.message}"
         end
       end
-    end
-    obj.type_info = [param_type_info]
+      obj.type_info = [param_type_info]
 
-    statement.pops_obj.tap do |o|
-      if o.parent_class
-        obj.parent_class = P(:root, o.parent_class)
+      statement.pops_obj.tap do |o|
+        if o.parent_class
+          obj.parent_class = P(:root, o.parent_class)
+        end
       end
-    end
 
-    register obj
+      register obj
+    rescue StandardError, SystemStackError => e
+      # If we hit this, we've thrown an exception somewhere that should be
+      # addressed but should not break the build.
+      #
+      # SystemStackError is being caught due to a presently untraced bug in
+      # either YARD or the Puppet Parser.
+      #
+      # Note: Documentation will *not* be generated for any item listed here,
+      # but you will get the rest of your documentation!
+
+      $stderr.puts("Ignored: #{e.inspect} at #{obj.title}")
+    end
   end
 end


### PR DESCRIPTION
This patch catches and reports on issues that have occurred during YARD
processing of the data to be processed.

The issue itself is not resolved but this does provide you with as much
documentation as can be reasonably generated for your materials without
crashing the build.

This was the result of the Baltimore Puppet Users Group Meetup of 22
June 2016.