### PR TITLE
(maint) Tie YARD to version 0.8.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ gemspec
 
 gem 'rgen'
 gem 'redcarpet'
+gem "yard", "~> 0.8.7"
 
 puppetversion = ENV['PUPPET_VERSION']
 


### PR DESCRIPTION
Prior to this commit, we were not setting a specific version of
YARD in the Gemfile. Since YARD has a lot of potential to break the
way strings works since strings relies so much on YARD internals,
we should be more deliberate about deciding to upgrade to a new
YARD version.

Once the kinks are worked out with the 0.9 release of YARD, we will
update the Gemfile again.