### PR TITLE
(maint) Update YARD to latest version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gemspec
 
 gem 'rgen'
 gem 'redcarpet'
-gem "yard", "~> 0.8.7"
+gem "yard", "~> 0.9.3"
 
 puppetversion = ENV['PUPPET_VERSION']
 

--- a/spec/unit/puppet_x/puppetlabs/strings/yard/defined_type_handler_spec.rb
+++ b/spec/unit/puppet_x/puppetlabs/strings/yard/defined_type_handler_spec.rb
@@ -64,6 +64,9 @@ describe PuppetX::PuppetLabs::Strings::YARD::Handlers::DefinedTypeHandler do
         define puppet_enterprise::mcollective::client::certs { }
     PUPPET
 
+    YARD::CodeObjects.send(:remove_const, :CONSTANTSTART)
+    YARD::CodeObjects::CONSTANTSTART = /^[a-zA-Z]/
+
     parse(puppet_code, :puppet)
     # If the namespace is not correctly generated, we will not be able to find the
     # object via this name, meaning namespace will be nil

--- a/spec/unit/puppet_x/puppetlabs/strings/yard/host_class_handler_spec.rb
+++ b/spec/unit/puppet_x/puppetlabs/strings/yard/host_class_handler_spec.rb
@@ -54,6 +54,9 @@ describe PuppetX::PuppetLabs::Strings::YARD::Handlers::HostClassHandler do
         class puppet_enterprise::mcollective::client::certs { }
     PUPPET
 
+    YARD::CodeObjects.send(:remove_const, :CONSTANTSTART)
+    YARD::CodeObjects::CONSTANTSTART = /^[a-zA-Z]/
+
     parse(puppet_code, :puppet)
     # If the namespace is not correctly generated, we will not be able to find the
     # object via this name, meaning namespace will be nil
@@ -72,6 +75,7 @@ Files:           1
 Modules:         0 (    0 undocumented)
 Classes:         0 (    0 undocumented)
 Constants:       0 (    0 undocumented)
+Attributes:      0 (    0 undocumented)
 Methods:         0 (    0 undocumented)
 Puppet Classes:     1 (    0 undocumented)
 Puppet Defined Types:     0 (    0 undocumented)


### PR DESCRIPTION
Prior to this commit, puppet strings tests were failing against YARD
versions 0.9.0 and newer. This was due to 1) a change in the YARD
results output and 2) the upstream patch we submitted in PDOC-25
being released.

The upstream patch we submitted for that ticket added a regular
expression that we could override when matching the names of puppet
classes and defines since they begin with lowercase letters (unlike
Ruby). Until this was released with the new YARD gem, we were using
a different method of fixing this issue. Once the gem was out, the tests
started failing because the regex override doesn't propagate to the
tests.

In order to fix the failing tests, override the regex in the tests
as well.