### PR TITLE
(PDOC-75) Strings calls 'interpret_any' with the wrong number of arguments

### DIFF
--- a/lib/puppet_x/puppetlabs/strings/yard/handlers/defined_type_handler.rb
+++ b/lib/puppet_x/puppetlabs/strings/yard/handlers/defined_type_handler.rb
@@ -16,7 +16,13 @@ class PuppetX::PuppetLabs::Strings::YARD::Handlers::DefinedTypeHandler < PuppetX
         param_type_info[pop_param.name] = Puppet::Pops::Types::TypeFactory.any()
       else
         begin
-          param_type_info[pop_param.name] =  tp.interpret_any(pop_param.type_expr)
+          # This is a bit of a hack because we were using a method that was previously
+          # API private. See PDOC-75 for more details
+          if Puppet::Pops::Types::TypeParser.instance_method(:interpret_any).arity == 2
+            param_type_info[pop_param.name] = tp.interpret_any(pop_param.type_expr, nil)
+          else
+            param_type_info[pop_param.name] = tp.interpret_any(pop_param.type_expr)
+          end
         rescue Puppet::ParseError => e
           # If the type could not be interpreted insert a prominent warning
           param_type_info[pop_param.name] = "Type Error: #{e.message}"


### PR DESCRIPTION
Puppet strings uses an API private method in puppet which has been updated to take two parameters instead of one. This means strings is calling it with the wrong number of variables in the defined type handler which is causing it to crash:

https://github.com/puppetlabs/puppetlabs-strings/blob/master/lib/puppet_x/puppetlabs/strings/yard/handlers/defined_type_handler.rb#L19